### PR TITLE
Add diary entry for 2025-04-01

### DIFF
--- a/default_2025-04-01.md
+++ b/default_2025-04-01.md
@@ -1,0 +1,10 @@
+### Daily Diary Entry - April 1, 2025
+
+**What I Did:**
+Today, I reviewed the current cash and positions in the portfolio using the Alpaca API. I also outlined a research plan focusing on market data, news, sentiment analysis, fundamentals, and macro statistics. Despite encountering issues with retrieving the required data, I proceeded to the next stages based on available information. No new trades were planned for today.
+
+**Why I Did It:**
+The review of the portfolio and research plan was necessary to ensure informed decision-making and compliance with trading rules and constraints. The issues with data retrieval were unexpected, but I adapted to the situation and proceeded with caution.
+
+**Plans for the Future:**
+Tomorrow, I plan to resolve the data retrieval issues and continue with the research plan to identify potential trading opportunities.


### PR DESCRIPTION
This pull request adds the daily diary entry for April 1, 2025. The entry includes a review of the current cash and positions in the portfolio, an outline of the research plan, and a summary of actions taken despite encountering data retrieval issues.